### PR TITLE
Fix date handling in generate_llm_schema

### DIFF
--- a/analysis/analyzer.py
+++ b/analysis/analyzer.py
@@ -3,7 +3,7 @@ import os
 import sys
 import json
 from typing import Dict, Type, Optional, List, Union, get_args, get_origin
-from datetime import datetime
+from datetime import datetime, date
 from instructor.multimodal import PDF
 
 from pydantic import BaseModel
@@ -67,7 +67,7 @@ def generate_llm_schema(model_cls: type[BaseModel], *,
                     int:  "integer",
                     float: "number",
                     bool: "boolean",
-                    datetime.date: "string(date)",
+                    date: "string(date)",
                     datetime: "string(date-time)",
                 }.get(tp, tp.__name__)
             # already a ForwardRef / Annotated / stringified type

--- a/tests/test_generate_llm_schema.py
+++ b/tests/test_generate_llm_schema.py
@@ -1,0 +1,15 @@
+import json
+from datetime import date
+
+from analysis.analyzer import generate_llm_schema
+from pydantic import BaseModel
+
+class SampleModel(BaseModel):
+    some_date: date
+    some_text: str
+
+
+def test_generate_llm_schema_includes_date_type():
+    schema = generate_llm_schema(SampleModel, as_json=True)
+    assert schema['some_date']['type'] == 'string(date)'
+    assert schema['some_text']['type'] == 'string'


### PR DESCRIPTION
## Summary
- fix date type lookup in `generate_llm_schema`
- add regression test for date schema handling

## Testing
- `bash run_tests.sh` *(fails: could not install pytest)*