### PR TITLE
Update comment for classify-only flag

### DIFF
--- a/diligentizer.py
+++ b/diligentizer.py
@@ -345,7 +345,7 @@ def main():
         # step and simply return the result from the auto model, which is effectively a classification.
         classify_only = False
 
-        # The --auto-only switch disables running the model that the auto model selected.
+        # The --classify-only switch disables running the model that the auto model selected.
         if args.classify_only:
             classify_only = True
         


### PR DESCRIPTION
## Summary
- fix the comment in `diligentizer.py` to mention `--classify-only` instead of the removed `--auto-only`

## Testing
- `./run_tests.sh` *(fails: could not install pytest)*