### PR TITLE
Fix employment salary tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,11 +48,9 @@ def mock_employment_data():
         "job_title": "Senior Software Engineer",
         "agreement_date": "2023-02-15",
         "effective_start_date": "2023-03-01",
-        "salary": {
-            "annual_amount": 120000.00,
-            "currency": "USD",
-            "payment_frequency": "bi-weekly"
-        },
+        "salary_amount": 120000.00,
+        "salary_currency": "USD",
+        "salary_payment_frequency": "bi-weekly",
         "bonuses": [
             {
                 "description": "Performance bonus",
@@ -114,11 +112,9 @@ def mock_llm_response_employment():
         "job_title": "Senior Software Engineer",
         "agreement_date": "2023-02-15",
         "effective_start_date": "2023-03-01",
-        "salary": {
-            "annual_amount": 120000.00,
-            "currency": "USD",
-            "payment_frequency": "bi-weekly"
-        },
+        "salary_amount": 120000.00,
+        "salary_currency": "USD",
+        "salary_payment_frequency": "bi-weekly",
         "bonuses": [
             {
                 "description": "Performance bonus",

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -114,9 +114,9 @@ class TestAnalyzer:
         
         # Create the nested objects with proper structure
         salary_data = {
-            "annual_amount": 120000.00,
-            "currency": "USD",
-            "payment_frequency": "Bi-weekly"
+            "salary_amount": 120000.00,
+            "salary_currency": "USD",
+            "salary_payment_frequency": "Bi-weekly"
         }
         
         termination_clauses = {
@@ -144,7 +144,7 @@ class TestAnalyzer:
             "job_title": "Senior Software Engineer",
             "agreement_date": date(2023, 1, 1),
             "effective_start_date": date(2023, 1, 15),
-            "salary": salary_data,
+            **salary_data,
             "bonuses": [],
             "benefits_description": "Standard company benefits package",
             "vacation_policy_description": "15 days paid vacation annually",
@@ -169,9 +169,9 @@ class TestAnalyzer:
         assert result.employer == "ABC Corporation"
         assert result.employee == "Jane Doe"
         assert result.job_title == "Senior Software Engineer"
-        assert result.salary.annual_amount == 120000.00
-        assert result.salary.currency == "USD"
-        assert result.salary.payment_frequency == "Bi-weekly"
+        assert result.salary_amount == 120000.00
+        assert result.salary_currency == "USD"
+        assert result.salary_payment_frequency == "Bi-weekly"
         assert result.governing_law == "California"
         assert result.termination_clauses.for_cause == "Immediate termination for gross misconduct"
         assert result.restrictive_covenants.confidentiality_clause_present is True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,8 +38,8 @@ class TestModelClasses:
         assert employment_model.employee == "Jane Doe"
         assert employment_model.job_title == "Senior Software Engineer"
         assert employment_model.agreement_date == date(2023, 2, 15)
-        assert employment_model.salary.annual_amount == 120000.00
-        assert employment_model.salary.currency == "USD"
+        assert employment_model.salary_amount == 120000.00
+        assert employment_model.salary_currency == "USD"
         assert len(employment_model.bonuses) == 1
         
         # Test the JSON serialization
@@ -47,8 +47,8 @@ class TestModelClasses:
         assert "employer" in json_data
         assert "employee" in json_data
         assert "job_title" in json_data
-        assert "salary" in json_data
-        assert "annual_amount" in json_data["salary"]
+        assert "salary_amount" in json_data
+        assert "salary_currency" in json_data
         
     def test_model_encoder(self):
         """Test the ModelEncoder for JSON serialization."""


### PR DESCRIPTION
## Summary
- update employment contract tests to use flat salary fields
- adjust fixtures for new salary keys
- keep analysis tests consistent with salary field rename

## Testing
- `./run_tests.sh` *(fails: Could not find a version that satisfies the requirement pytest==7.4.0)*